### PR TITLE
chore: automate GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "src/agent_config_score/__init__.py"
+      - ".github/workflows/release.yml"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Read package version
+        id: version
+        shell: bash
+        run: |
+          version="$(python - <<'PY'
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          PY
+          )"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Create GitHub release when missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="v${VERSION}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "$tag already exists; nothing to do."
+            exit 0
+          fi
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --title "AgentConfigScore $tag" \
+            --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## v0.3.0
+
+### Added
+
+- First-class composite GitHub Action via root `action.yml`.
+- Copy-paste pull-request regression workflow using `LE0-Lin/AgentConfigScore@v0`.
+- Automatic PR base-SHA resolution and temporary baseline worktree management.
+- GitHub Actions Step Summary output for regression reports.
+- Input validation for `base-sha`, `max-drop`, and `fail-on-new-errors`.
+- Self-dogfooding workflow that runs the local action on AgentConfigScore's own pull requests.
+
+### Changed
+
+- README now leads with the regression-gate use case and 30-second GitHub Actions integration.
+- Package version bumped to `0.3.0`.
+
+## v0.2.0
+
+### Added
+
+- Baseline-to-candidate `compare` command.
+- Score-delta reporting with new and resolved findings.
+- `--max-drop`, `--fail-on-new-errors`, and Markdown summary output.
+- Pull-request regression workflow.
+
+## v0.1.0
+
+### Added
+
+- Deterministic 0–100 agent-config scoring.
+- Detection for duplication, contradictions, dead paths, dangerous shell commands, and common secret patterns.
+- HTML report and SVG badge generation.


### PR DESCRIPTION
## Summary

Prepare AgentConfigScore for repeatable public releases.

- add an idempotent GitHub Actions release workflow
- read the package version directly from `pyproject.toml`
- create `vX.Y.Z` tag + GitHub Release only when missing
- add a changelog covering v0.1.0 through v0.3.0

The workflow has `contents: write` only on pushes to `main` and is intentionally scoped to version/release-workflow changes. Merging this PR should create the first `v0.3.0` Release automatically.