### PR TITLE
ci: build and verify release distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,39 @@ jobs:
           assert data["runs"][0]["tool"]["driver"]["name"] == "AgentConfigScore"
           PY
 
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Build wheel and source distribution
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install build
+          python -m build
+          test "$(find dist -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 1
+          test "$(find dist -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 1
+      - name: Install wheel in an isolated environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          wheel="$(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -type f -name '*.whl' -print -quit)"
+          expected="$(python - <<'PY'
+          import tomllib
+          with open('pyproject.toml', 'rb') as handle:
+              print(tomllib.load(handle)['project']['version'])
+          PY
+          )"
+          python -m venv "$RUNNER_TEMP/agent-config-score-wheel-test"
+          "$RUNNER_TEMP/agent-config-score-wheel-test/bin/python" -m pip install "$wheel"
+          cd "$RUNNER_TEMP"
+          actual="$("$RUNNER_TEMP/agent-config-score-wheel-test/bin/agent-config-score" --version)"
+          test "$actual" = "AgentConfigScore $expected"
+          "$RUNNER_TEMP/agent-config-score-wheel-test/bin/agent-config-score" --help >/dev/null
+
   score_history:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/score-history.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,33 +11,97 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+
       - name: Read package version
         id: version
         shell: bash
         run: |
+          set -euo pipefail
           version="$(python - <<'PY'
           import tomllib
-          with open('pyproject.toml', 'rb') as f:
-              print(tomllib.load(f)['project']['version'])
+          with open('pyproject.toml', 'rb') as handle:
+              print(tomllib.load(handle)['project']['version'])
           PY
           )"
           echo "version=$version" >> "$GITHUB_OUTPUT"
-      - name: Create GitHub release when missing
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check release state
+        id: preflight
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "$TAG already has a GitHub Release; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            tagged_sha="$(git rev-list -n 1 "$TAG")"
+            if [[ "$tagged_sha" != "$GITHUB_SHA" ]]; then
+              echo "error: $TAG already points to $tagged_sha, not current commit $GITHUB_SHA" >&2
+              exit 2
+            fi
+            echo "existing_tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "existing_tag=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build wheel and source distribution
+        if: steps.preflight.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install build
+          python -m build
+          test "$(find dist -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 1
+          test "$(find dist -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 1
+          (cd dist && sha256sum -- * > SHA256SUMS.txt)
+
+      - name: Validate built wheel
+        if: steps.preflight.outputs.skip != 'true'
+        env:
           VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
-          tag="v${VERSION}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "$tag already exists; nothing to do."
-            exit 0
+          wheel="$(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -type f -name '*.whl' -print -quit)"
+          python -m venv "$RUNNER_TEMP/agent-config-score-release-test"
+          "$RUNNER_TEMP/agent-config-score-release-test/bin/python" -m pip install "$wheel"
+          cd "$RUNNER_TEMP"
+          actual="$("$RUNNER_TEMP/agent-config-score-release-test/bin/agent-config-score" --version)"
+          test "$actual" = "AgentConfigScore $VERSION"
+          "$RUNNER_TEMP/agent-config-score-release-test/bin/agent-config-score" --help >/dev/null
+
+      - name: Create GitHub release with verified distributions
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          EXISTING_TAG: ${{ steps.preflight.outputs.existing_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$EXISTING_TAG" == "true" ]]; then
+            gh release create "$TAG" dist/* \
+              --verify-tag \
+              --title "AgentConfigScore $TAG" \
+              --generate-notes
+          else
+            gh release create "$TAG" dist/* \
+              --target "$GITHUB_SHA" \
+              --title "AgentConfigScore $TAG" \
+              --generate-notes
           fi
-          gh release create "$tag" \
-            --target "$GITHUB_SHA" \
-            --title "AgentConfigScore $tag" \
-            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,23 +41,36 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "$TAG already has a GitHub Release; nothing to do."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          release_exists=false
+          tag_exists=false
 
-          echo "skip=false" >> "$GITHUB_OUTPUT"
           if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            tag_exists=true
             tagged_sha="$(git rev-list -n 1 "$TAG")"
             if [[ "$tagged_sha" != "$GITHUB_SHA" ]]; then
+              if gh release view "$TAG" >/dev/null 2>&1; then
+                echo "$TAG already exists at $tagged_sha; current commit is $GITHUB_SHA. Leaving the existing release untouched."
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                echo "existing_tag=true" >> "$GITHUB_OUTPUT"
+                echo "existing_release=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
               echo "error: $TAG already points to $tagged_sha, not current commit $GITHUB_SHA" >&2
               exit 2
             fi
-            echo "existing_tag=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "existing_tag=false" >> "$GITHUB_OUTPUT"
           fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            release_exists=true
+            if [[ "$tag_exists" != "true" ]]; then
+              echo "error: GitHub Release $TAG exists but its tag was not fetched locally" >&2
+              exit 2
+            fi
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "existing_tag=$tag_exists" >> "$GITHUB_OUTPUT"
+          echo "existing_release=$release_exists" >> "$GITHUB_OUTPUT"
 
       - name: Build wheel and source distribution
         if: steps.preflight.outputs.skip != 'true'
@@ -85,16 +98,19 @@ jobs:
           test "$actual" = "AgentConfigScore $VERSION"
           "$RUNNER_TEMP/agent-config-score-release-test/bin/agent-config-score" --help >/dev/null
 
-      - name: Create GitHub release with verified distributions
+      - name: Publish verified distributions
         if: steps.preflight.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
           EXISTING_TAG: ${{ steps.preflight.outputs.existing_tag }}
+          EXISTING_RELEASE: ${{ steps.preflight.outputs.existing_release }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$EXISTING_TAG" == "true" ]]; then
+          if [[ "$EXISTING_RELEASE" == "true" ]]; then
+            gh release upload "$TAG" dist/* --clobber
+          elif [[ "$EXISTING_TAG" == "true" ]]; then
             gh release create "$TAG" dist/* \
               --verify-tag \
               --title "AgentConfigScore $TAG" \


### PR DESCRIPTION
## Summary

Make AgentConfigScore's manual GitHub release path produce and verify real Python distribution artifacts instead of creating a tag/release with no package assets.

### CI packaging contract

A new `package` job now:

- builds exactly one wheel and one source distribution
- creates a fresh virtual environment
- installs the built wheel rather than the source tree
- runs the installed `agent-config-score --version` and `--help`
- verifies the installed version matches `pyproject.toml`

### Manual release hardening

The existing `workflow_dispatch` release remains manual. When triggered it now:

- fetches full history and tags
- reads the package version and target tag
- refuses a conflicting tag that points at a different commit
- safely leaves an existing release untouched when it belongs to another commit
- if a Marketplace/GitHub Release already exists for the current commit, builds and safely attaches/clobbers the verified distribution assets
- otherwise creates the missing release/tag only after package validation succeeds
- builds wheel + sdist
- generates `SHA256SUMS.txt`
- installs and smoke-tests the built wheel in an isolated environment
- uploads the wheel, sdist, and checksum file as release assets

This preserves manual Marketplace/release control while making fixed releases reproducible and directly downloadable.

### Validation

The final candidate passed the full Linux/Windows/macOS matrix, score-history workflow and output contract, dogfood regression gate, and the new package job including isolated wheel installation.

No runtime package behavior or scoring logic changes.