### PR TITLE
ci: verify Python 3.10 through 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,13 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
           - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
             python-version: "3.12"
           - os: ubuntu-latest
             python-version: "3.13"
+          - os: ubuntu-latest
+            python-version: "3.14"
           - os: windows-latest
             python-version: "3.12"
           - os: macos-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,20 @@ authors = [{name = "Zhibo Lin"}]
 keywords = ["agents-md", "claude-code", "cursor", "copilot", "ai-agents", "github-actions", "ci", "developer-tools"]
 classifiers = [
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
+
+[project.urls]
+Homepage = "https://github.com/LE0-Lin/AgentConfigScore"
+Repository = "https://github.com/LE0-Lin/AgentConfigScore"
+Issues = "https://github.com/LE0-Lin/AgentConfigScore/issues"
+Changelog = "https://github.com/LE0-Lin/AgentConfigScore/blob/main/CHANGELOG.md"
 
 [project.scripts]
 agent-config-score = "agent_config_score.entrypoint:main"


### PR DESCRIPTION
## Summary

Turn AgentConfigScore's `Python 3.10+` compatibility claim into a complete tested contract and improve distribution metadata for future package indexes/releases.

### Runtime matrix

Linux CI now tests every current supported CPython minor from 3.10 through 3.14:

- Python 3.10
- Python 3.11
- Python 3.12
- Python 3.13
- Python 3.14

Windows and macOS continue to run the full product suite on Python 3.12.

### Package metadata

`pyproject.toml` now publishes explicit Python 3.10–3.14 classifiers plus project links for Homepage, Repository, Issues, and Changelog.

The existing package-build job will also verify that this metadata can still be built into a wheel/sdist and that the wheel installs cleanly in isolation.

No scanner, scoring, policy, or Action behavior changes.