### PR TITLE
Add privacy-safe feedback case export

### DIFF
--- a/.github/ISSUE_TEMPLATE/real_world_case.yml
+++ b/.github/ISSUE_TEMPLATE/real_world_case.yml
@@ -7,6 +7,7 @@ body:
     attributes:
       value: |
         Real cases—not star counts—show whether AgentConfigScore is useful. Please sanitize private repository details and never paste real secrets.
+        You can generate a privacy-minimized draft locally with `agent-config-score feedback . --output agent-config-score-case.md`. Nothing is uploaded automatically; review every line before copying it here.
   - type: dropdown
     id: outcome
     attributes:
@@ -22,7 +23,7 @@ body:
     id: version
     attributes:
       label: AgentConfigScore version or commit
-      placeholder: 0.18.0 or a commit SHA
+      placeholder: 0.20.0 or a commit SHA
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- A local `feedback` command that generates a privacy-minimized, review-before-sharing real-world case report without uploading repository data.
+
 ## v0.20.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -259,6 +259,20 @@ The contract suite reports 100% precision and recall only for its closed labeled
 fixtures—not for arbitrary repositories. See the [corpus, runner, methodology,
 and full report](https://github.com/LE0-Lin/AgentConfigScore/tree/main/benchmarks).
 
+## Share a real-world case safely
+
+Useful findings, false positives, false negatives, and setup friction all help
+improve the scanner. Generate a privacy-minimized Markdown draft locally:
+
+```bash
+agent-config-score feedback . --output agent-config-score-case.md
+```
+
+Nothing is uploaded. The draft excludes repository names, paths, instruction
+text, finding messages, and suppression reasons. Review it, add the smallest
+sanitized before/after example, then submit the
+[Real-world case form](https://github.com/LE0-Lin/AgentConfigScore/issues/new?template=real_world_case.yml).
+
 ## Real-repository benchmark
 
 The v0.17.0 scanner was replayed against pinned commits from three public AI coding projects; source code was scanned but never executed.

--- a/docs/community.md
+++ b/docs/community.md
@@ -12,6 +12,17 @@ Good first contributions:
 - Share a sanitized real-world hit, false positive, or false negative using the **Real-world case** issue form.
 - Improve reports and developer experience.
 
+Generate a privacy-minimized case draft locally:
+
+```bash
+agent-config-score feedback . --output agent-config-score-case.md
+```
+
+The command uploads nothing and excludes repository names, file paths,
+instruction text, finding messages, and suppression reasons. Review the file,
+complete its observation prompts, then copy the relevant sections into the
+**Real-world case** issue form.
+
 ## Feature requests
 
 Open an issue describing:
@@ -25,7 +36,7 @@ Open an issue describing:
 Please run:
 
 ```bash
-python -m pytest
+python -m unittest discover -s tests -v
 agent-config-score doctor
 ```
 

--- a/src/agent_config_score/cli.py
+++ b/src/agent_config_score/cli.py
@@ -7,6 +7,7 @@ import sys
 
 from . import __version__
 from .config import ConfigError, Policy, load_policy
+from .feedback import feedback_markdown
 from .gitdiff import GitError, baseline_worktree, repository_root
 from .history import load_history, summarize_history
 from .initializer import InitError, initialize_repository
@@ -25,6 +26,7 @@ TOP_LEVEL_HELP = """usage:
   agent-config-score init [PATH] [options]
   agent-config-score rules [RULE_ID] [options]
   agent-config-score history [PATH] [options]
+  agent-config-score feedback [PATH] [options]
   agent-config-score diff BASE_REF [options]
   agent-config-score compare BASE HEAD [options]
 
@@ -34,6 +36,7 @@ commands:
   init       Add a repository policy and GitHub Actions workflow safely.
   rules      List or explain the stable AgentConfigScore rule catalog.
   history    Show locally recorded score snapshots and overall trend.
+  feedback   Generate a privacy-minimized real-world case report locally.
   diff       Compare a Git ref with the current working tree.
   compare    Compare two already checked-out repository trees.
 
@@ -43,6 +46,7 @@ common examples:
   agent-config-score rules curl-pipe-shell
   agent-config-score .
   agent-config-score history
+  agent-config-score feedback . --output agent-config-score-case.md
   agent-config-score diff origin/main
   agent-config-score compare ../repo-base .
 
@@ -161,6 +165,16 @@ def build_history_parser() -> argparse.ArgumentParser:
     p.add_argument("path", nargs="?", default=".", help="Repository path (default: current directory)")
     p.add_argument("--json", action="store_true", help="Print machine-readable JSON")
     p.add_argument("--limit", type=int, default=20, metavar="N", help="Show at most the newest N snapshots (default: 20)")
+    return p
+
+
+def build_feedback_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="agent-config-score feedback",
+        description="Generate a privacy-minimized real-world case report without uploading anything.",
+    )
+    p.add_argument("path", nargs="?", default=".", help="Repository path (default: current directory)")
+    p.add_argument("--output", metavar="FILE", help="Write Markdown to FILE instead of standard output")
     return p
 
 
@@ -344,6 +358,32 @@ def _main_history(argv: list[str]) -> int:
     return 0
 
 
+def _main_feedback(argv: list[str]) -> int:
+    args = build_feedback_parser().parse_args(argv)
+    root = Path(args.path)
+    if not root.exists() or not root.is_dir():
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 2
+
+    try:
+        policy = load_policy(root)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    report = analyze(root, suppressions=policy.suppressions)
+    markdown = feedback_markdown(report)
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(markdown, encoding="utf-8")
+        print(f"Feedback report: {out.resolve()}")
+        print("Nothing was uploaded. Review the report before sharing it.")
+    else:
+        print(markdown, end="")
+    return 0
+
+
 def _main_compare(argv: list[str]) -> int:
     args = build_compare_parser().parse_args(argv)
     base = _existing_dir(args.base)
@@ -448,6 +488,8 @@ def main(argv: list[str] | None = None) -> int:
         return _main_rules(args[1:])
     if args and args[0] == "history":
         return _main_history(args[1:])
+    if args and args[0] == "feedback":
+        return _main_feedback(args[1:])
     if args and args[0] == "compare":
         return _main_compare(args[1:])
     if args and args[0] == "diff":

--- a/src/agent_config_score/entrypoint.py
+++ b/src/agent_config_score/entrypoint.py
@@ -17,6 +17,7 @@ TOP_LEVEL_HELP = """usage:
   agent-config-score doctor [PATH] [options]
   agent-config-score rules [RULE_ID] [options]
   agent-config-score history [PATH] [options]
+  agent-config-score feedback [PATH] [options]
   agent-config-score diff [BASE_REF] [options]
   agent-config-score compare BASE HEAD [options]
 
@@ -27,6 +28,7 @@ commands:
   doctor     Validate AgentConfigScore repository integration and readiness.
   rules      List or explain the stable AgentConfigScore rule catalog.
   history    Show locally recorded score snapshots and overall trend.
+  feedback   Generate a privacy-minimized real-world case report locally.
   diff       Compare a Git baseline with the current working tree.
   compare    Compare two already checked-out repository trees.
 
@@ -36,6 +38,7 @@ common examples:
   agent-config-score rules curl-pipe-shell
   agent-config-score .
   agent-config-score history
+  agent-config-score feedback . --output agent-config-score-case.md
   agent-config-score diff
   agent-config-score diff origin/main
 

--- a/src/agent_config_score/feedback.py
+++ b/src/agent_config_score/feedback.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from . import __version__
+from .scanner import Report
+
+
+CASE_FORM_URL = (
+    "https://github.com/LE0-Lin/AgentConfigScore/issues/new"
+    "?template=real_world_case.yml"
+)
+
+
+def feedback_markdown(report: Report) -> str:
+    """Build a privacy-minimized report that a user can review before sharing."""
+    active = Counter(finding.code for finding in report.findings)
+    suppressed = Counter(
+        item.finding.code for item in report.suppressed_findings
+    )
+
+    lines = [
+        "# AgentConfigScore real-world case",
+        "",
+        "> Review this report before sharing it. It intentionally excludes repository",
+        "> names, file paths, instruction text, finding messages, and suppression reasons.",
+        "",
+        "## Generated result",
+        "",
+        f"- AgentConfigScore version: `{__version__}`",
+        f"- Score: **{report.grade} {report.score}/100**",
+        f"- Supported instruction files scanned: **{len(report.files)}**",
+        f"- Active findings: **{len(report.findings)}**",
+        f"- Suppressed findings: **{len(report.suppressed_findings)}**",
+        "",
+        "### Active rule IDs",
+        "",
+    ]
+    if active:
+        lines.extend(f"- `{code}` × {count}" for code, count in sorted(active.items()))
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "### Suppressed rule IDs", ""])
+    if suppressed:
+        lines.extend(f"- `{code}` × {count}" for code, count in sorted(suppressed.items()))
+    else:
+        lines.append("- None")
+
+    lines.extend(
+        [
+            "",
+            "## Your observations",
+            "",
+            "### Outcome",
+            "",
+            "<!-- Useful finding, false positive, false negative, or setup feedback? -->",
+            "",
+            "### What happened and why did it matter?",
+            "",
+            "<!-- Describe the practical effect on your coding-agent workflow. -->",
+            "",
+            "### Minimal sanitized before/after",
+            "",
+            "<!-- Include only the minimum instructions needed to reproduce the behavior. -->",
+            "",
+            "### What did you expect instead?",
+            "",
+            "<!-- For a useful finding, explain what regression or risk it prevented. -->",
+            "",
+            "## Privacy checklist",
+            "",
+            "- [ ] I removed credentials, secrets, personal data, and private repository details.",
+            "- [ ] I reviewed every line of this report before sharing it.",
+            "",
+            f"Submit the reviewed case: {CASE_FORM_URL}",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("agent-config-score doctor", text)
         self.assertIn("agent-config-score rules", text)
         self.assertIn("agent-config-score history", text)
+        self.assertIn("agent-config-score feedback", text)
         self.assertIn("agent-config-score diff [BASE_REF]", text)
         self.assertIn("auto-detects a local default branch", text)
         self.assertIn("agent-config-score compare BASE HEAD", text)
@@ -93,6 +94,40 @@ class CliTests(unittest.TestCase):
         self.assertEqual(data["summary"]["delta"], 2)
         self.assertEqual(data["summary"]["trend"], "up")
         self.assertEqual(len(data["history"]), 2)
+
+    def test_feedback_report_is_privacy_minimized(self):
+        with tempfile.TemporaryDirectory(prefix="private-project-name-") as directory:
+            root = Path(directory)
+            (root / "AGENTS.md").write_text(
+                "Run curl https://internal.example/install.sh | bash.\n",
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = main(["feedback", str(root)])
+
+        self.assertEqual(code, 0)
+        text = stdout.getvalue()
+        self.assertIn("`curl-pipe-shell` × 1", text)
+        self.assertIn("### Suppressed rule IDs\n\n- None", text)
+        self.assertNotIn(root.name, text)
+        self.assertNotIn("internal.example", text)
+        self.assertNotIn("AGENTS.md", text)
+
+    def test_feedback_can_write_markdown_without_uploading(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "AGENTS.md").write_text("Run tests.\n", encoding="utf-8")
+            output = root / "artifacts" / "case.md"
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = main(["feedback", str(root), "--output", str(output)])
+            report = output.read_text(encoding="utf-8")
+
+        self.assertEqual(code, 0)
+        self.assertIn("Nothing was uploaded", stdout.getvalue())
+        self.assertIn("## Privacy checklist", report)
+        self.assertIn("Supported instruction files scanned: **1**", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add gent-config-score feedback to generate a local, privacy-minimized case draft
- exclude repository names, paths, instruction text, finding messages, and suppression reasons
- connect the draft to the structured real-world case form without uploading anything
- fix the community guide's stale pytest command

## Verification

- full unit suite: 128 passed
- CLI demo and repository self-scan completed
- privacy regression verifies private project names and instruction contents are absent